### PR TITLE
changed water height so jelly fish are now visible again

### DIFF
--- a/Assets/Prefabs/FX/WeatherEffects.prefab
+++ b/Assets/Prefabs/FX/WeatherEffects.prefab
@@ -466,7 +466,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012563267608}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -2.43, z: 0}
+  m_LocalPosition: {x: 0, y: -4.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4000011538390944}


### PR DESCRIPTION
fixes #795 

literally just a prefab update, just pull down and make sure you can see the jelly fish now. To go by this quickly I would recommend you go to the spawning scene